### PR TITLE
Fix controller's service definition

### DIFF
--- a/src/DependencyInjection/StaticPassthroughExtension.php
+++ b/src/DependencyInjection/StaticPassthroughExtension.php
@@ -8,6 +8,7 @@ use MakinaCorpus\StaticPassthroughBundle\Controller\StaticPassthroughController;
 use MakinaCorpus\StaticPassthroughBundle\Routing\StaticPassthroughRouteLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 class StaticPassthroughExtension extends ConfigurableExtension
@@ -20,6 +21,7 @@ class StaticPassthroughExtension extends ConfigurableExtension
         // Define StaticPassthroughController service
         $definition = new Definition();
         $definition->setClass(StaticPassthroughController::class);
+        $definition->addMethodCall('setContainer', [new Reference('service_container')]);
         $definition->addTag('controller.service_arguments');
         $definition->setPrivate(true);
 

--- a/src/DependencyInjection/StaticPassthroughExtension.php
+++ b/src/DependencyInjection/StaticPassthroughExtension.php
@@ -20,7 +20,7 @@ class StaticPassthroughExtension extends ConfigurableExtension
         // Define StaticPassthroughController service
         $definition = new Definition();
         $definition->setClass(StaticPassthroughController::class);
-        $definition->setTags(['controller.service_arguments']);
+        $definition->addTag('controller.service_arguments');
         $definition->setPrivate(true);
 
         $container->setDefinition(StaticPassthroughController::class, $definition);


### PR DESCRIPTION
Two fixes:

- Service definition validity pass fails because the `controller.service_arguments` tag is not correctly added to the controller's service definition. I fixed it by using the `addTag()` method instead of `setTags()`.
- After that, when I try to access to a route managed by the `StaticPassthroughController`, I get the following exception:
  
  > "MakinaCorpus\StaticPassthroughBundle\Controller\StaticPassthroughController" has no container set, did you forget to define it as a service subscriber?
  
  By being registered via the extension, the controller does not benefit from the autowiring. Therefore I ask the container to inject itself into the controller by using the `setContainer()` method.
