### PR TITLE
add return types

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('static_passthrough');
 

--- a/src/DependencyInjection/StaticPassthroughExtension.php
+++ b/src/DependencyInjection/StaticPassthroughExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 class StaticPassthroughExtension extends ConfigurableExtension
 {
-    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
         // Set Static Passthrough parameter in container
         $container->setParameter('static_passthrough.definitions', $mergedConfig['definitions'] ?? []);


### PR DESCRIPTION
otherwise, later versions of PHP throw an error.